### PR TITLE
Fix spawnlimbo.py not allowing to respawn

### DIFF
--- a/pique/spawnlimbo.py
+++ b/pique/spawnlimbo.py
@@ -242,6 +242,10 @@ def apply_script(protocol, connection, config):
 		spawn_limbo_loop = None
 		
 		def on_kill(c, by, kill_type, grenade):
+			entities = list(c.team.get_entities())
+			if len(entities) < 1:
+				return connection.on_kill(c, by, kill_type, grenade)
+
 			p = c.protocol
 			c.allowed_to_spawn = False
 			c.spawn_time = time() + c.get_respawn_time()


### PR DESCRIPTION
This fixes a bug when your team didnt captured any territory yet (this happen a lot when all territories are neutral).
So it checks if your team has territories, if not it will just allow you to respawn normally.