### PR TITLE
replay.py: add better TC support

### DIFF
--- a/pique/replay.py
+++ b/pique/replay.py
@@ -439,6 +439,7 @@ def apply_script(protocol, connection, config):
 				state_data.state = ctf_data
 	
 			elif game_mode == TC_MODE:
+				tc_data.set_entities(self.entities)
 				state_data.state = tc_data
 			
 			self.saved_packets.append(state_data)


### PR DESCRIPTION
Bug: If you recorded a TC server, the recordings cause OpenSpades to disconnect after map transfer. 
Fix: It turns out that the entity positions have to be added to the packet by a function of tc_data.