### PR TITLE
Update replay.py: Fix issue with recorder ID

### DIFF
--- a/pique/replay.py
+++ b/pique/replay.py
@@ -304,6 +304,8 @@ def apply_script(protocol, connection, config):
 			self.record_length = None
 			self.auto_delete_if_too_small()
 			self.is_auto = False
+			if self.recorder_id <32:    
+				self.player_ids.put_back(self.recorder_id)
 		
 		def write_pack(self, contained):
 			data = ByteWriter()


### PR DESCRIPTION
This change fixes a bug that caused ID 31 to be exceeded by players because the recorder got more IDs reserved than it needed